### PR TITLE
Fixing a problem with yii2 and --coverage-html

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -131,10 +131,12 @@ class Yii2 extends Framework implements ActiveRecord, PartedModule
 
         $this->client = new Yii2Connector();
         $this->client->defaultServerVars = [
-            'SCRIPT_FILENAME' => $entryFile,
-            'SCRIPT_NAME'     => $entryScript,
-            'SERVER_NAME'     => parse_url($entryUrl, PHP_URL_HOST),
-            'SERVER_PORT'     => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
+            'SCRIPT_FILENAME'       => $entryFile,
+            'SCRIPT_NAME'           => $entryScript,
+            'SERVER_NAME'           => parse_url($entryUrl, PHP_URL_HOST),
+            'SERVER_PORT'           => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
+            'REQUEST_TIME'          => time(),
+            'REQUEST_TIME_FLOAT'    => microtime(true),            
         ];
         $this->client->defaultServerVars['HTTPS'] = parse_url($entryUrl, PHP_URL_SCHEME) === 'https';
         $this->client->restoreServerVars();


### PR DESCRIPTION
Fixing a problem with yii2 module that when asking for  --coverage-html throws an error. 

To duplicate the problem run 
composer create-project --prefer-dist --stability=dev yiisoft/yii2-app-basic basic
cd basic
vendor/codeception/base/codecept run functional --coverage-html

When creating code coverage this line is hit
https://github.com/sebastianbergmann/php-code-coverage/blob/2.2/src/CodeCoverage/Report/Text.php#L121
and an  Undefined index: REQUEST_TIME error is thrown.

This fix is to provide the REQUEST_TIME variable to phpunit.

This might be because I am using PHP 5.4 and I am getting an old version of phpunit.
